### PR TITLE
Revamp command registry system

### DIFF
--- a/PowerBuilder/Commands/pcmdAddParameters.cs
+++ b/PowerBuilder/Commands/pcmdAddParameters.cs
@@ -1,0 +1,134 @@
+#region Namespaces
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Extensions;
+using PowerBuilder.Infrastructure;
+using PowerBuilder.Interfaces;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+#endregion
+
+namespace PowerBuilder.Commands
+{
+    [Transaction(TransactionMode.Manual)]
+    public class pcmdAddParameters : CmdBase {
+        public override string DisplayName { get; } = "Add Parameters";
+        public override string ShortDesc { get; } = "Select a partial parameter file and add Parameters to the active Family Document";
+        public override bool RibbonIncludeFlag { get; set; } = true; 
+        public override Result Execute(
+          ExternalCommandData commandData,
+          ref string message,
+          ElementSet elements){
+
+            UIApplication uiapp = commandData.Application;
+            UIDocument uidoc = uiapp.ActiveUIDocument;
+            Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
+            Document doc = uidoc.Document;
+            
+            Log.Debug($"{this.GetType()}");
+            Log.Debug("TEST-ADD-PARAMETERS");
+
+            if (doc.IsFamilyDocument) {
+
+                //all of this can probably be implemented as a base class "FileBased" or "RequiresFile"
+                //can you do this as an attribute? [UserSelectedFile]
+                FamilyManager famMan = doc.FamilyManager;
+                List<ExternalDefinition> parameterDefs = ParseParameterDefs(uiapp);
+                using (Transaction T = new Transaction(doc, "batch-add-parameters")) {
+                    T.Start();
+                    foreach (ExternalDefinition pDef in parameterDefs) {
+                        //the thought here is to enable parameter definitions to be marked with an invalid GUID in the file, instead of trying to find some 
+                        //
+                        Log.Debug($"Try-Add\t{pDef.Name}");
+                        bool isInstance = true;
+                        ForgeTypeId groupTypeId = pDef.GetGroupTypeId();
+                        if (pDef.GUID.ToString() != "-1") {
+                            ForgeTypeId specTypeId = pDef.GetDataType();
+                            //famMan.AddParameter(pDef.Name, groupTypeId, specTypeId, isInstance);
+                            Log.Debug("valid GUID ok");
+                        }
+                        else {
+                            //famMan.AddParameter(pDef, groupTypeId, isInstance);
+                            Log.Debug("not a valid GUID");
+                        }
+                    }
+                    T.Commit();
+                }
+            }
+            else {
+                TaskDialog msg = new TaskDialog("Add Parameters");
+                msg.MainContent = "Run this command in a Family Document";
+                msg.Show();
+            }
+
+
+
+            return Result.Succeeded;
+        }
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
+            throw new NotImplementedException("No input collection required");
+        }
+
+        private List<ExternalDefinition> ParseParameterDefs(UIApplication uiapp) {
+
+            //need to do this thing where we float and swap the current shared parameter path
+            //Id really like to be able to accommodate Family and Shared parameters here.  my thought 
+            Log.Debug("ENTER ParseParameterDefs");
+            
+            Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
+            string referenceSpPath = app.SharedParametersFilename;
+
+            
+            app.SharedParametersFilename = GetFilePath();
+            DefinitionFile spFile = app.OpenSharedParameterFile();
+
+            Log.Debug($"access spfile {spFile.Filename}");
+            List<ExternalDefinition> externalDefinitions = ExtractDefinitionsFromGroups(spFile.Groups).ToList();
+            Log.Debug($"found {externalDefinitions.Count} itemss");
+
+            app.SharedParametersFilename = referenceSpPath;
+            return externalDefinitions;
+        }
+        private string GetFilePath() {
+            Log.Debug("ENTER GetFilePath");
+
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.InitialDirectory = "c:\\";
+            openFileDialog.Filter = "txt files (*.txt)|*.txt|All files (*.*)|*.*";
+            openFileDialog.FilterIndex = 2;
+            openFileDialog.RestoreDirectory = true;
+
+            string path = null;
+
+            if (openFileDialog.ShowDialog() == DialogResult.OK) {
+
+                Debug.WriteLine("first point");
+                path = openFileDialog.FileName;
+            }
+            return path;
+        }
+        private List<ExternalDefinition> ExtractDefinitionsFromGroups(DefinitionGroups dgs) {
+            Log.Debug("ENTER ExtractDefinitionsFromGroups");
+            Log.Debug($"{dgs.Size} groups");
+            List<ExternalDefinition> extDefs = new List<ExternalDefinition>();
+
+            foreach (DefinitionGroup dg in dgs) {
+                Debug.WriteLine($"found DefinitionGroup {dg.Name}");
+                foreach (ExternalDefinition def in dg.Definitions) {
+                    Debug.WriteLine($"found definition {def.Name}");
+                    extDefs.Add(def);
+                }
+            }
+
+            return extDefs;
+        }
+    }
+}

--- a/PowerBuilder/Commands/pcmdClassifyElementSpec.cs
+++ b/PowerBuilder/Commands/pcmdClassifyElementSpec.cs
@@ -16,18 +16,18 @@ using System.Diagnostics;
 using System.Text.Json.Serialization;
 using PowerBuilder.Objects;
 using System.Text.Json;
-using PowerBuilder.Services;
+using PowerBuilder.Infrastructure;
 
 #endregion
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdClassifyElementSpec : IPowerCommand {
-        public string DisplayName { get; } = "Classify Element Specification";
-        public string ShortDesc { get; } = "Connect with Claude to report estimated Element Clasification";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdClassifyElementSpec : CmdBase {
+        public override string DisplayName { get; } = "Classify Element Specification";
+        public override string ShortDesc { get; } = "Connect with Claude to report estimated Element Clasification";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -65,7 +65,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
     }

--- a/PowerBuilder/Commands/pcmdClassifySpaceType.cs
+++ b/PowerBuilder/Commands/pcmdClassifySpaceType.cs
@@ -9,6 +9,7 @@ using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using PowerBuilder.Claude;
 using PowerBuilder.Extensions;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Objects;
 using PowerBuilder.SelectionFilter;
@@ -26,11 +27,11 @@ using System.Text.Json.Serialization;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdClassifySpaceType : IPowerCommand {
-        public string DisplayName { get; } = "Classify Space";
-        public string ShortDesc { get; } = "Connect with Claude to Classify the Space Type";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdClassifySpaceType : CmdBase{
+        public override string DisplayName { get; } = "Classify Space";
+        public override string ShortDesc { get; } = "Connect with Claude to Classify the Space Type";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -72,7 +73,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
     }

--- a/PowerBuilder/Commands/pcmdDependencyMapper.cs
+++ b/PowerBuilder/Commands/pcmdDependencyMapper.cs
@@ -11,15 +11,16 @@ using static System.Windows.Forms.VisualStyles.VisualStyleElement.TreeView;
 using PowerBuilderUI;
 using PowerBuilder.Interfaces;
 using Serilog;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdDependencyMapper : IPowerCommand{
-        public string DisplayName { get; } = "Dependency Mapper";
-        public string ShortDesc { get; } = "Graphically Display the element dependency of a selected Element or Type";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
+    public class pcmdDependencyMapper : CmdBase{
+        public override string DisplayName { get; } = "Dependency Mapper";
+        public override string ShortDesc { get; } = "Graphically Display the element dependency of a selected Element or Type";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
             UIApplication uiapp = commandData.Application;
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
@@ -38,7 +39,7 @@ namespace PowerBuilder.Commands
             
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             // so how does this actually want to work. This is usually type based, except for classes that don't have types
             // line styles
             // text styles

--- a/PowerBuilder/Commands/pcmdDisableScheduleUnits.cs
+++ b/PowerBuilder/Commands/pcmdDisableScheduleUnits.cs
@@ -4,6 +4,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -14,12 +15,12 @@ using System.Diagnostics;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdDisableScheduleUnits : IPowerCommand {
-        public string DisplayName { get; } = "Disable Schedule Units";
-        public string ShortDesc { get; } = "Set all numeric Schedule Fields to use the ForgeTypeId <empty>";
-        public bool RibbonIncludeFlag { get; } = true;
+    public class pcmdDisableScheduleUnits : CmdBase{
+        public override string DisplayName { get; } = "Disable Schedule Units";
+        public override string ShortDesc { get; } = "Set all numeric Schedule Fields to use the ForgeTypeId <empty>";
+        public override bool RibbonIncludeFlag { get; set; } = true;
         private Document _doc;
-        public Result Execute(
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -49,7 +50,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             PowerDialogResult res = new PowerDialogResult();
 
             UIDocument uidoc = uiapp.ActiveUIDocument;

--- a/PowerBuilder/Commands/pcmdFamilyLibraryScanner.cs
+++ b/PowerBuilder/Commands/pcmdFamilyLibraryScanner.cs
@@ -13,17 +13,18 @@ using System.Xml;
 using System.Linq;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using System.Windows.Forms;
+using PowerBuilder.Infrastructure;
 
 #endregion
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdFamilyLibraryScanner : IPowerCommand {
-        public string DisplayName { get; } = "Family Library Scanner";
-        public string ShortDesc { get; } = "Select a directory to scan and produce a report with family name, size, authoring version, and category";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdFamilyLibraryScanner : CmdBase{
+        public override string DisplayName { get; } = "Family Library Scanner";
+        public override string ShortDesc { get; } = "Select a directory to scan and produce a report with family name, size, authoring version, and category";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -43,7 +44,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             PowerDialogResult res = new PowerDialogResult();
             
             FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog();

--- a/PowerBuilder/Commands/pcmdHelloWorld.cs
+++ b/PowerBuilder/Commands/pcmdHelloWorld.cs
@@ -4,6 +4,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using Serilog;
 using System;
@@ -15,11 +16,11 @@ using System.Diagnostics;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdHelloWorld : IPowerCommand {
-        public string DisplayName { get; } = "Hello World!";
-        public string ShortDesc { get; } = "A standard Hello, World command in Revit";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdHelloWorld : CmdBase{
+        public override string DisplayName { get; } = "Hello World!";
+        public override string ShortDesc { get; } = "A standard Hello, World command in Revit";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -34,7 +35,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
     }

--- a/PowerBuilder/Commands/pcmdMatchElevation.cs
+++ b/PowerBuilder/Commands/pcmdMatchElevation.cs
@@ -10,16 +10,17 @@ using System.Threading.Tasks;
 using PowerBuilder.SelectionFilter;
 using PowerBuilder.Extensions;
 using Nice3point.Revit.Extensions;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands {
 
     [Transaction(TransactionMode.Manual)]
-    internal class pcmdMatchElevation : IPowerCommand {
-        public string DisplayName { get; } = "Match Service Elevation";
-        public string ShortDesc { get; } = "Set a target service element elevation match the source element elevation";
-        public bool RibbonIncludeFlag { get; } = true;
+    internal class pcmdMatchElevation : CmdBase{
+        public override string DisplayName { get; } = "Match Service Elevation";
+        public override string ShortDesc { get; } = "Set a target service element elevation match the source element elevation";
+        public override bool RibbonIncludeFlag { get; set; } = true;
 
-        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
+        public override Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
             UIApplication uiapp = commandData.Application;
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
@@ -49,7 +50,7 @@ namespace PowerBuilder.Commands {
             return Result.Succeeded;
         }
 
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             PowerDialogResult res = new PowerDialogResult();
             UIDocument uidoc = uiapp.ActiveUIDocument;
 

--- a/PowerBuilder/Commands/pcmdMepMapper.cs
+++ b/PowerBuilder/Commands/pcmdMepMapper.cs
@@ -6,6 +6,7 @@ using Autodesk.Revit.DB.Mechanical;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using Microsoft.Msagl.Drawing;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using PowerBuilder.SelectionFilter;
 using PowerBuilder.Utils;
@@ -22,11 +23,11 @@ using System.Runtime.CompilerServices;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdMepMapper : IPowerCommand {
-        public string DisplayName { get; } = "MEP Map";
-        public string ShortDesc { get; } = "Produce a system graphic for based on the selection.";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdMepMapper : CmdBase{
+        public override string DisplayName { get; } = "MEP Map";
+        public override string ShortDesc { get; } = "Produce a system graphic for based on the selection.";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -46,7 +47,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             UIDocument uidoc = uiapp.ActiveUIDocument;
             PowerDialogResult res = new PowerDialogResult();
             Selection sel = uidoc.Selection;

--- a/PowerBuilder/Commands/pcmdSelectiveTransfer.cs
+++ b/PowerBuilder/Commands/pcmdSelectiveTransfer.cs
@@ -11,17 +11,18 @@ using System.Linq;
 using PowerBuilderUI.Forms;
 using PowerBuilderUI;
 using PowerBuilder.Interfaces;
+using PowerBuilder.Infrastructure;
 
 #endregion
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdSelectiveTransfer : IPowerCommand {
-        public string DisplayName { get; } = "Selective Transfer";
-        public string ShortDesc { get; } = "Select Element Types to copy from the source document to the target document";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdSelectiveTransfer : CmdBase{
+        public override string DisplayName { get; } = "Selective Transfer";
+        public override string ShortDesc { get; } = "Select Element Types to copy from the source document to the target document";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -38,7 +39,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
             // In the other one, i called the active doc_tar and the others doc_src

--- a/PowerBuilder/Commands/pcmdSetArrowheadTypes.cs
+++ b/PowerBuilder/Commands/pcmdSetArrowheadTypes.cs
@@ -4,6 +4,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using PowerBuilderUI.Forms;
 using System;
@@ -18,11 +19,11 @@ using System.Windows.Forms;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdSetArrowheadTypes : IPowerCommand {
-        public string DisplayName { get; } = "Set Arrowhead by Type";
-        public string ShortDesc { get; } = "Select a family and specify the Arrowhead Type to associate with that family";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdSetArrowheadTypes : CmdBase{
+        public override string DisplayName { get; } = "Set Arrowhead by Type";
+        public override string ShortDesc { get; } = "Select a family and specify the Arrowhead Type to associate with that family";
+        public override bool RibbonIncludeFlag { get; set;} = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -125,7 +126,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("method not implemented");
         }
         private void pcdrSetArrowheadByRefTargets(Element source, List<Element> targets, Document doc) {

--- a/PowerBuilder/Commands/pcmdSwapUnitDefinitions.cs
+++ b/PowerBuilder/Commands/pcmdSwapUnitDefinitions.cs
@@ -5,6 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using PowerBuilder.Extensions;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using Serilog;
 using System;
@@ -18,11 +19,11 @@ using System.Xml;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdSwapUnitDefinitions : IPowerCommand {
-        public string DisplayName { get; } = "Swap Unit Specifications";
-        public string ShortDesc { get; } = "Write current Unit Specification and load cached Unit Specification";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdSwapUnitDefinitions : CmdBase{
+        public override string DisplayName { get; } = "Swap Unit Specifications";
+        public override string ShortDesc { get; } = "Write current Unit Specification and load cached Unit Specification";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -75,7 +76,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
 

--- a/PowerBuilder/Commands/pcmdTEST.cs
+++ b/PowerBuilder/Commands/pcmdTEST.cs
@@ -5,6 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using PowerBuilder.Extensions;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using Serilog;
 using System;
@@ -16,11 +17,11 @@ using System.Diagnostics;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdTEST : IPowerCommand {
-        public string DisplayName { get; } = "TEST FUNCTION";
-        public string ShortDesc { get; } = "Container command for testing logic";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdTEST : CmdBase{
+        public override string DisplayName { get; } = "TEST FUNCTION";
+        public override string ShortDesc { get; } = "Container command for testing logic";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -57,7 +58,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
     }

--- a/PowerBuilder/Commands/pcmdTextUnion.cs
+++ b/PowerBuilder/Commands/pcmdTextUnion.cs
@@ -11,19 +11,20 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using PowerBuilder.Interfaces;
 using PowerBuilder.SelectionFilter;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
 
 
     [Transaction(TransactionMode.Manual)]
-    public class pcmdTextUnion : IPowerCommand {
-        public string DisplayName { get; } = "Text Union";
-        public string ShortDesc { get; } =  "Concatenate TextNote contents into one TextNote";
-        public bool RibbonIncludeFlag { get; } = true;
+    public class pcmdTextUnion : CmdBase{
+        public override string DisplayName { get; } = "Text Union";
+        public override string ShortDesc { get; } =  "Concatenate TextNote contents into one TextNote";
+        public override bool RibbonIncludeFlag { get; set; } = true;
 
         
-        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
+        public override Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
             UIApplication uiapp = commandData.Application;
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Autodesk.Revit.ApplicationServices.Application app = uiapp.Application;
@@ -36,7 +37,7 @@ namespace PowerBuilder.Commands
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Document doc = uidoc.Document;
             

--- a/PowerBuilder/Commands/pcmdToggleOrigins.cs
+++ b/PowerBuilder/Commands/pcmdToggleOrigins.cs
@@ -10,15 +10,16 @@ using static UIFramework.Widget.CustomControls.NativeMethods;
 using Autodesk.Revit.Attributes;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Utils;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdToggleOrigins: IPowerCommand {
-        public string DisplayName { get; } = "Toggle Origins";
-        public string ShortDesc { get; } = "Toggle the Internal Origin, Project Base Point, and Survey Point visibility in the active view";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdToggleOrigins: CmdBase{
+        public override string DisplayName { get; } = "Toggle Origins";
+        public override string ShortDesc { get; } = "Toggle the Internal Origin, Project Base Point, and Survey Point visibility in the active view";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -54,7 +55,7 @@ namespace PowerBuilder.Commands
             
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput (UIApplication uiapp) {
+        public override PowerDialogResult GetInput (UIApplication uiapp) {
             throw new NotImplementedException("Method not used");
         }
     }

--- a/PowerBuilder/Commands/pcmdToggleSectionBox.cs
+++ b/PowerBuilder/Commands/pcmdToggleSectionBox.cs
@@ -10,15 +10,16 @@ using static UIFramework.Widget.CustomControls.NativeMethods;
 using Autodesk.Revit.Attributes;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Utils;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdToggleSectionBox : IPowerCommand {
-        public string DisplayName { get; } = "Toggle Section Box";
-        public string ShortDesc { get; } = "Toggle the Section Box visibility in the active view";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdToggleSectionBox : CmdBase{
+        public override string DisplayName { get; } = "Toggle Section Box";
+        public override string ShortDesc { get; } = "Toggle the Section Box visibility in the active view";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -47,7 +48,7 @@ namespace PowerBuilder.Commands
             
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput (UIApplication uiapp) {
+        public override PowerDialogResult GetInput (UIApplication uiapp) {
             throw new NotImplementedException("Method not used");
         }
     }

--- a/PowerBuilder/Commands/pcmdToggleVerifyAndLogUpdater.cs
+++ b/PowerBuilder/Commands/pcmdToggleVerifyAndLogUpdater.cs
@@ -8,19 +8,20 @@ using Autodesk.Revit.UI;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Extensions;
 using Autodesk.Revit.Attributes;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdToggleVerifyAndLogUpdater : IPowerCommand {
+    public class pcmdToggleVerifyAndLogUpdater : CmdBase{
 
-        public string DisplayName { get; } = "Toggle VerifyAndLog Updater";
-        public string ShortDesc { get; } = $"Toggle VerifyAndLog utility state.";
-        public bool RibbonIncludeFlag { get; } = true;
+        public override string DisplayName { get; } = "Toggle VerifyAndLog Updater";
+        public override string ShortDesc { get; } = $"Toggle VerifyAndLog utility state.";
+        public override bool RibbonIncludeFlag { get; set; } = true;
 
         private Guid _TargetUIpdaterId = new  Guid( "4D7EC7FB-A211-44B9-8F0B-5BA675475F81");
         private bool _IsInitialRun = false;
 
-        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
+        public override Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
             
             UIApplication uiapp = commandData.Application;
             UIDocument uidoc = uiapp.ActiveUIDocument;
@@ -53,7 +54,7 @@ namespace PowerBuilder.Commands {
 
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
 

--- a/PowerBuilder/Commands/pcmdToggleViewProjection.cs
+++ b/PowerBuilder/Commands/pcmdToggleViewProjection.cs
@@ -9,15 +9,16 @@ using System.Threading.Tasks;
 using static UIFramework.Widget.CustomControls.NativeMethods;
 using Autodesk.Revit.Attributes;
 using PowerBuilder.Interfaces;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdToggleViewProjection : IPowerCommand {
-        public string DisplayName { get; } = "Toggle View Projection";
-        public string ShortDesc { get; } = "Toggle the View Projection state in the active view";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdToggleViewProjection : CmdBase{
+        public override string DisplayName { get; } = "Toggle View Projection";
+        public override string ShortDesc { get; } = "Toggle the View Projection state in the active view";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -48,7 +49,7 @@ namespace PowerBuilder.Commands
             }
             
         }
-        public PowerDialogResult GetInput (UIApplication uiapp) {
+        public override PowerDialogResult GetInput (UIApplication uiapp) {
             throw new NotImplementedException("Method not used");
         }
     }

--- a/PowerBuilder/Commands/pcmdToggleViewSync.cs
+++ b/PowerBuilder/Commands/pcmdToggleViewSync.cs
@@ -5,6 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Services;
 using Serilog;
@@ -17,11 +18,11 @@ using System.Diagnostics;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdToggleViewSync : IPowerCommand {
-        public string DisplayName { get; } = "Toggle View Sync";
-        public string ShortDesc { get; } = "Active View Synchronization";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdToggleViewSync : CmdBase{
+        public override string DisplayName { get; } = "Toggle View Sync";
+        public override string ShortDesc { get; } = "Active View Synchronization";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -45,7 +46,7 @@ namespace PowerBuilder.Commands
             Log.Information("Vss State change {initial} -> {final}", VssInitial, Vss.Status);
                 return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
     }

--- a/PowerBuilder/Commands/pcmdTrimElementsToScopeBox.cs
+++ b/PowerBuilder/Commands/pcmdTrimElementsToScopeBox.cs
@@ -5,6 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using Serilog;
 using System;
@@ -16,11 +17,11 @@ using System.Diagnostics;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdTrimElementsToScopeBox : IPowerCommand {
-        public string DisplayName { get; } = "Trim Elements to Beyond View";
-        public string ShortDesc { get; } = "Delete all elements not visible in the Active View.  Use this to generate partial plans for Renovation scope of work";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdTrimElementsToScopeBox : CmdBase{
+        public override string DisplayName { get; } = "Trim Elements to Beyond View";
+        public override string ShortDesc { get; } = "Delete all elements not visible in the Active View.  Use this to generate partial plans for Renovation scope of work";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements)
@@ -51,7 +52,7 @@ namespace PowerBuilder.Commands
             
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("No input collection required");
         }
         public void TrimModelElementsBeyondActiveView(Document doc) {

--- a/PowerBuilder/Commands/pcmdUpdateViewTemplateByTags.cs
+++ b/PowerBuilder/Commands/pcmdUpdateViewTemplateByTags.cs
@@ -10,18 +10,19 @@ using Autodesk.Revit.Attributes;
 using Nice3point.Revit.Extensions;
 using PowerBuilder.Extensions;
 using PowerBuilder.Interfaces;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdUpdateViewTemplatesByVTsequence : IPowerCommand {
-        public string DisplayName { get; } = "Update View Templates by Layer";
-        public string ShortDesc { get; } = "Sets view accessible view properties according to Templates listed in the parameter \"TemplateLayers\" to each view template." +
+    public class pcmdUpdateViewTemplatesByVTsequence : CmdBase{
+        public override string DisplayName { get; } = "Update View Templates by Layer";
+        public override string ShortDesc { get; } = "Sets view accessible view properties according to Templates listed in the parameter \"TemplateLayers\" to each view template." +
             "Graphic Overrides from all Layered Templates are combined." +
             "\nUnmodifiable options:\n" +
             "\tShadows\n\tLighting\n\tPhotographic Exposure\n\n" +
             "Control these independently in the View Template's settings. They are unchanged by this procedure.";
-        public bool RibbonIncludeFlag { get; } = false;
+        public override bool RibbonIncludeFlag { get; set; } = false;
         //TODO: manage control parameter and RibbonIncludeFlag as part of startup
         /* There are special cases that need to be considered
              *      Overrides: manipulate these using the Get and Set methods
@@ -59,7 +60,7 @@ namespace PowerBuilder.Commands
                 BuiltInParameter.VIS_GRAPHICS_FILTERS,
             };
         private static Definition _controlParam;
-        public Result Execute(
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -98,7 +99,7 @@ namespace PowerBuilder.Commands
             }
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("method not used");
         }
         /// <summary>

--- a/PowerBuilder/Commands/pcmdUpdateViewTemplateByViewLayers.cs
+++ b/PowerBuilder/Commands/pcmdUpdateViewTemplateByViewLayers.cs
@@ -11,20 +11,21 @@ using Nice3point.Revit.Extensions;
 using PowerBuilder.Extensions;
 using PowerBuilder.Interfaces;
 using PowerBuilder.Services;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdUpdateViewTemplatesByViewLayers : IPowerCommand {
-        public string DisplayName { get; } = "Update View Templates by Layer";
-        public string ShortDesc { get; } = "Sets view accessible view properties according to Templates listed in the parameter \"TemplateLayers\" to each view template." +
+    public class pcmdUpdateViewTemplatesByViewLayers : CmdBase{
+        public override string DisplayName { get; } = "Update View Templates by Layer";
+        public override string ShortDesc { get; } = "Sets view accessible view properties according to Templates listed in the parameter \"TemplateLayers\" to each view template." +
             "Graphic Overrides from all Layered Templates are combined." +
             "\nUnmodifiable options:\n" +
             "\tShadows\n\tLighting\n\tPhotographic Exposure\n\n" +
             "Control these independently in the View Template's settings. They are unchanged by this procedure.";
-        public bool RibbonIncludeFlag { get; } = true;
+        public override bool RibbonIncludeFlag { get; set; } = true;
         
-        public Result Execute(
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -61,7 +62,7 @@ namespace PowerBuilder.Commands
             }
             return Result.Succeeded;
         }
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             throw new NotImplementedException("method not used");
         }
     }

--- a/PowerBuilder/Commands/pcmdVectorMeasure.cs
+++ b/PowerBuilder/Commands/pcmdVectorMeasure.cs
@@ -8,14 +8,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 
 namespace PowerBuilder.Commands {
     [Transaction(TransactionMode.Manual)]
-    internal class pcmdVectorMeasure: IPowerCommand {
-        public string DisplayName { get; } = "Vector Measure";
-        public string ShortDesc { get; } = "Display vector components from Start Point to End Point";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
+    internal class pcmdVectorMeasure: CmdBase{
+        public override string DisplayName { get; } = "Vector Measure";
+        public override string ShortDesc { get; } = "Display vector components from Start Point to End Point";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements) {
             
             UIApplication uiapp = commandData.Application;
             UIDocument uidoc = uiapp.ActiveUIDocument;
@@ -37,7 +38,7 @@ namespace PowerBuilder.Commands {
             return Result.Succeeded;
         }
 
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
             
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Document doc = uidoc.Document;

--- a/PowerBuilder/Commands/pcmdVerifyAndLog.cs
+++ b/PowerBuilder/Commands/pcmdVerifyAndLog.cs
@@ -5,6 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Interfaces;
 using PowerBuilder.SelectionFilter;
 using PowerBuilder.Utils;
@@ -24,11 +25,11 @@ using System.Windows.Forms;
 namespace PowerBuilder.Commands
 {
     [Transaction(TransactionMode.Manual)]
-    public class pcmdVerifyAndLog : IPowerCommand {
-        public string DisplayName { get; } = "Verify and Log";
-        public string ShortDesc { get; } = "Mark verification parameter, Pin, and produce work log for selected elements";
-        public bool RibbonIncludeFlag { get; } = true;
-        public Result Execute(
+    public class pcmdVerifyAndLog : CmdBase{
+        public override string DisplayName { get; } = "Verify and Log";
+        public override string ShortDesc { get; } = "Mark verification parameter, Pin, and produce work log for selected elements";
+        public override bool RibbonIncludeFlag { get; set; } = true;
+        public override Result Execute(
           ExternalCommandData commandData,
           ref string message,
           ElementSet elements) {
@@ -59,7 +60,7 @@ namespace PowerBuilder.Commands
         /// </summary>
         /// <param name="uiapp"></param>
         /// <returns></returns>
-        public PowerDialogResult GetInput(UIApplication uiapp) {
+        public override PowerDialogResult GetInput(UIApplication uiapp) {
 
             UIDocument uidoc = uiapp.ActiveUIDocument;
             Document doc = uidoc.Document;

--- a/PowerBuilder/Infrastructure/CmdBase.cs
+++ b/PowerBuilder/Infrastructure/CmdBase.cs
@@ -1,0 +1,31 @@
+﻿using Autodesk.Revit.UI;
+using PowerBuilder.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerBuilder.Infrastructure {
+    /// <summary>
+    /// Base class for IExternalCommands managed by PowerBuilder. Includes identification
+    /// and ribbon status properties
+    /// </summary>
+    public abstract class CmdBase : IExternalCommand {
+        //add ValidScope or equivalent enum designating where the command is valid
+        public abstract string DisplayName { get; }
+        public abstract string ShortDesc { get; }
+        public virtual bool RibbonIncludeFlag { get; set; }
+
+        public abstract Result Execute(
+          ExternalCommandData commandData,
+          ref string message,
+          ElementSet elements);
+
+        public abstract PowerDialogResult GetInput(UIApplication uiapp);
+
+        public CmdSignature GetCommandSignature() {
+            return new CmdSignature(DisplayName, ShortDesc, RibbonIncludeFlag);
+        }
+    }
+}

--- a/PowerBuilder/Infrastructure/CmdRegistry.cs
+++ b/PowerBuilder/Infrastructure/CmdRegistry.cs
@@ -1,0 +1,80 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using FilterTreeControlWPF;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerBuilder.Infrastructure {
+    /// <summary>
+    /// CmdRegistry is a singleton class to track command state and related methods for composing the Ribbona
+    /// </summary>
+    public sealed class CmdRegistry {
+        private static readonly CmdRegistry _instance = new CmdRegistry();
+        private static Dictionary<string, CmdSignature> _commandRegistry = new Dictionary<string, CmdSignature>();
+        //do we need to provide a static reference to the application resources? is this controller more than just the command registry?
+        static CmdRegistry() {
+            
+        }
+        private CmdRegistry() {
+                     
+        }
+        public static CmdRegistry Instance {
+            get {
+                return _instance;
+            }
+        }
+        public void ComposeRibbon(UIControlledApplication uicapp) {
+            //TOOD: these concerns should be separated. this is probably fine, but this should be some other sort of deal RibbonManager
+            //that contains the Ribbon manipulation logic and only gets the command registry from CmdRegistry
+            RibbonPanel ribbonPanel = uicapp.CreateRibbonPanel("PowerBuilder");
+            PulldownButtonData pullDownData = new PulldownButtonData("pldbPBCommands", "Power Tools");
+            PulldownButton pullDownButton = ribbonPanel.AddItem(pullDownData) as PulldownButton;
+
+            //Collect Commands and compose into RibbonItems
+            string thisAssemblyPath = Assembly.GetExecutingAssembly().Location;
+            Debug.WriteLine($"PATH: {thisAssemblyPath}");
+            List<string> registrySequence = _commandRegistry.Keys.OrderBy(x => _commandRegistry[x].DisplayName).ToList();
+            
+            for (int i = 0; i < _commandRegistry.Count; i++) {
+                string ir = registrySequence[i];
+                if (_commandRegistry[ir].RibbonIncludeFlag) {
+                    Debug.WriteLine($"DisplayName: {_commandRegistry[ir].DisplayName}\t\t\tFullName {_commandRegistry[ir]}");
+                    PushButtonData CurrentPushButton = new PushButtonData($"PBCOM{i}", _commandRegistry[ir].DisplayName, thisAssemblyPath, ir);
+                    CurrentPushButton.ToolTip = _commandRegistry[ir].ShortDesc;
+                    pullDownButton.AddPushButton(CurrentPushButton);
+                }
+            }
+        }
+        public void InitializeRegistry() {
+
+            Assembly asm = Assembly.GetExecutingAssembly();
+            List<Type> commandTypes = asm.GetTypes()
+                .Where(t => typeof(CmdBase)
+                .IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+                .ToList();
+
+            foreach (System.Type Command in commandTypes) {
+                _commandRegistry.Add(Command.FullName, GetCommandData(Command));
+            }
+        }
+        private CmdSignature GetCommandData(Type cmdType) {
+            CmdBase cmd = Activator.CreateInstance(cmdType) as CmdBase;
+            return cmd.GetCommandSignature();
+        }
+        //these should really have error handling like if (isRegistered) else throw new ..
+        public void RegisterCmd (Type cmdType) {
+            _commandRegistry[cmdType.FullName].RibbonIncludeFlag = true;
+        }
+        public void UnregisterCmd(Type cmdType) {
+            _commandRegistry[cmdType.FullName].RibbonIncludeFlag = false;
+        }
+        //TODO: build document context aware event handlers
+    }
+}

--- a/PowerBuilder/Infrastructure/CmdSignature.cs
+++ b/PowerBuilder/Infrastructure/CmdSignature.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerBuilder.Infrastructure {
+    /// <summary>
+    /// Wrapper for commaand ui data
+    /// </summary>
+    public class CmdSignature {
+
+        private string _displayName;
+        private string _shortDesc;
+        public string DisplayName => _displayName;
+        public string ShortDesc => _shortDesc;
+        public bool RibbonIncludeFlag { get; set; }
+        //TODO: include icon path
+
+        public CmdSignature() { }
+        public CmdSignature(string displayName, string shortDesc, bool ribbonIncludeFlag = true) {
+            _displayName = displayName;
+            _shortDesc = shortDesc;
+            RibbonIncludeFlag = ribbonIncludeFlag;
+        }
+        
+    }
+}

--- a/PowerBuilder/Interfaces/IPowerCommand.cs
+++ b/PowerBuilder/Interfaces/IPowerCommand.cs
@@ -9,7 +9,11 @@ namespace PowerBuilder.Interfaces
 {
     /// <summary>
     /// Interface for implementing PowerBuilder commands
+    /// 
+    /// DEPRECATED. Create new commands from CmdBase
+    /// 
     /// </summary>
+    
     public interface IPowerCommand : IExternalCommand
     {
         string _displayName { get; }

--- a/PowerBuilder/Interfaces/IPowerCommand.cs
+++ b/PowerBuilder/Interfaces/IPowerCommand.cs
@@ -12,9 +12,9 @@ namespace PowerBuilder.Interfaces
     /// </summary>
     public interface IPowerCommand : IExternalCommand
     {
-        abstract string DisplayName { get; }
-        abstract string ShortDesc { get; }
-        abstract bool RibbonIncludeFlag { get; }
+        string _displayName { get; }
+        string ShortDesc { get; }
+        bool RibbonIncludeFlag { get; }
 
         ///<summary>
         /// User interaction should always be separated from command function.  Place the call for the Form here, or trigger Revit Selection UI

--- a/PowerBuilder/Services/ElementClassifier.cs
+++ b/PowerBuilder/Services/ElementClassifier.cs
@@ -1,6 +1,7 @@
 ﻿using Autodesk.Revit.DB;
 using PowerBuilder.Claude;
 using PowerBuilder.Extensions;
+using PowerBuilder.Infrastructure;
 using PowerBuilder.Objects;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
The previous implementation of the RibbonIncludeFlag never quite worked because this isn't using C#11+ where abstract static members are permitted.  This PR introduces several change to the automated Ribbon assembler
1. Introduce new class CmdSignature which is a wrapper for the attributes included to create ribbon buttons
2. Introduced new base class CmdBase to replace IPowerCommand. This includes a CmdSignature generator in the base class
3. Introduced CmdRegistry, a singleton to register commands to, and manipulate the RibbonIncludeStatus. This currently contains methods to compose the ribbon, but that should probably change in an upcoming PR